### PR TITLE
Fix missing main class in CLI launcher script

### DIFF
--- a/lokex-cli/build.gradle.kts
+++ b/lokex-cli/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     application
 }
 
+application {
+    mainClass.set("com.iodigital.lokex.MainKt")
+}
+
 kotlin {
     jvm()
 
@@ -16,16 +20,25 @@ kotlin {
     }
 }
 
+// Wire the application plugin to use the KMP JVM jar and its runtime classpath
+// so the generated launcher script has the correct classpath entries.
+val jvmJar by tasks.getting(Jar::class)
+val jvmRuntimeClasspath by configurations.getting
+
+tasks.named<CreateStartScripts>("startScripts") {
+    classpath = files(jvmJar.archiveFile) + jvmRuntimeClasspath
+}
+
 distributions {
     main {
         distributionBaseName.set("lokex")
         contents {
             into("") {
-                val jvmJar by tasks.getting
                 from(jvmJar)
                 from("src/lokex")
             }
             into("lib/") {
+                from(jvmJar)
                 val main by kotlin.jvm().compilations.getting
                 from(main.runtimeDependencyFiles)
             }


### PR DESCRIPTION
## Summary

The `application` Gradle plugin generates the launcher script at `bin/lokex-cli`, but without `mainClass` set, the script omits the main class from the `java` command. This causes the first CLI argument (e.g. `-c`) to be interpreted as a JVM option:

```
Unrecognized option: -c
Error: Could not create the Java Virtual Machine.
```

The fix adds `application { mainClass.set("com.iodigital.lokex.MainKt") }` to `lokex-cli/build.gradle.kts`. The main class was already configured in the jar manifest, but the `application` plugin needs it set separately.

Fixes #2